### PR TITLE
Fix format string vulnerability

### DIFF
--- a/lib/tdbus/_tdbus.c
+++ b/lib/tdbus/_tdbus.c
@@ -33,7 +33,7 @@
 
 #define RETURN_DBUS_ERROR(err) \
     do { \
-        if (dbus_error_is_set(&err)) RETURN_ERROR(err.message); \
+        if (dbus_error_is_set(&err)) RETURN_ERROR("%s", err.message); \
         else RETURN_ERROR("unknown error"); \
     } while (0)
 


### PR DESCRIPTION
The RETURN_DBUS_ERROR macro, defined and used in the `_tdbus.c` file,
would pass DBus error string as a format string to PyErr_Format.
This might be a security problem and would cause a compilation error
when `-Werror=format-security` GCC option is used (enabled by default on many Linux distributions now).

Fixes these:

```
lib/tdbus/_tdbus.c: In function '_tdbus_connection_open':
lib/tdbus/_tdbus.c:1325:13: error: format not a string literal and no format arguments [-Werror=format-security]
             RETURN_DBUS_ERROR(error);
             ^
lib/tdbus/_tdbus.c:1331:13: error: format not a string literal and no format arguments [-Werror=format-security]
             RETURN_DBUS_ERROR(error);
             ^
lib/tdbus/_tdbus.c:1337:13: error: format not a string literal and no format arguments [-Werror=format-security]
             RETURN_DBUS_ERROR(error);
             ^
lib/tdbus/_tdbus.c:1342:13: error: format not a string literal and no format arguments [-Werror=format-security]
             RETURN_DBUS_ERROR(error);
             ^
cc1: some warnings being treated as errors
```
