### PR TITLE
Include examples and doc files in src distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include AUTHORS HACKING LICENSE
+include examples/*.py


### PR DESCRIPTION
The archive created by 'python setup.py sdist' should contain
the complete code, including the examples and the 'AUTHORS, HACKING,
LICENSE' files.
