### PR TITLE
Do not force -O0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ version_info = {
 def pkgconfig(*args):
     """Run pkg-config."""
     output = subprocess.check_output(['pkg-config'] + list(args), universal_newlines=True)
-    return output.strip().split() + ['-O0']
+    return output.strip().split()
 
 
 setup(


### PR DESCRIPTION
Default compiler options should be safe, -O0 may break builds on some systems with GCC where FORTIFY_SOURCE is used by default.